### PR TITLE
Typo: remove trailing n in 'kube-systemn'

### DIFF
--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -179,7 +179,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: kube-systemn
+  namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -192,7 +192,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: horizontal-pod-autoscaler
-  namespace: kube-systemn
+  namespace: kube-system
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
remove typo from the namespace kube-systemn. Should be kube-system
