### PR TITLE
Fix validation error when specifying multiple metrics

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -36,50 +36,48 @@ type cloudwatchClient struct {
 }
 
 func (c *cloudwatchClient) Query(queries []config.MetricDataQuery) ([]cloudwatch.MetricDataResult, error) {
-	mdq := make([]cloudwatch.MetricDataQuery, len(queries))
+	// If changing logic in this function ensure changes are duplicated in
+	// `pkg/controller.handleExternalMetric()`
+	cwMetricQueries := make([]cloudwatch.MetricDataQuery, len(queries))
 	for i, q := range queries {
-		dimensions := make([]cloudwatch.Dimension, len(q.MetricStat.Metric.Dimensions))
-		for j, d := range q.MetricStat.Metric.Dimensions {
-			dimensions[j] = cloudwatch.Dimension{
-				Name:  &d.Name,
-				Value: &d.Value,
-			}
+		q := q
+		mdq := cloudwatch.MetricDataQuery{
+			Id:         &q.ID,
+			Label:      &q.Label,
+			ReturnData: &q.ReturnData,
 		}
-		metric := &cloudwatch.Metric{
-			Dimensions: dimensions,
-			MetricName: &q.MetricStat.Metric.MetricName,
-			Namespace:  &q.MetricStat.Metric.Namespace,
-		}
-		unit := cloudwatch.StandardUnit(q.MetricStat.Unit)
-		var metricStat *cloudwatch.MetricStat
-		expression := q.Expression
-		id := q.ID
-		var e *string
 
-		if len(expression) == 0 {
-			e = nil
-			metricStat = &cloudwatch.MetricStat{
+		if len(q.Expression) == 0 {
+			dimensions := make([]cloudwatch.Dimension, len(q.MetricStat.Metric.Dimensions))
+			for j, d := range q.MetricStat.Metric.Dimensions {
+				dimensions[j] = cloudwatch.Dimension{
+					Name:  &d.Name,
+					Value: &d.Value,
+				}
+			}
+
+			metric := &cloudwatch.Metric{
+				Dimensions: dimensions,
+				MetricName: &q.MetricStat.Metric.MetricName,
+				Namespace:  &q.MetricStat.Metric.Namespace,
+			}
+
+			mdq.MetricStat = &cloudwatch.MetricStat{
 				Metric: metric,
 				Period: &q.MetricStat.Period,
 				Stat:   &q.MetricStat.Stat,
-				Unit:   unit,
+				Unit:   cloudwatch.StandardUnit(q.MetricStat.Unit),
 			}
 		} else {
-			e = &expression
-			metricStat = nil
+			mdq.Expression = &q.Expression
 		}
-		mdq[i] = cloudwatch.MetricDataQuery{
-			Expression: e,
-			Id:         &id,
-			Label:      &q.Label,
-			MetricStat: metricStat,
-			ReturnData: &q.ReturnData,
-		}
+
+		cwMetricQueries[i] = mdq
+	}
+	cwQuery := cloudwatch.GetMetricDataInput{
+		MetricDataQueries: cwMetricQueries,
 	}
 
-	cwQuery := cloudwatch.GetMetricDataInput{
-		MetricDataQueries: mdq,
-	}
 	return c.QueryCloudWatch(cwQuery)
 }
 


### PR DESCRIPTION
This fixes an issue where the loop iterator variable for queries references the last specified `MetricStat` in the case of multiple metrics. The issue is evident in the following `ExternalMetric`:

```
apiVersion: metrics.aws/v1alpha1
kind: ExternalMetric
metadata:
  creationTimestamp: null
  name: rds-db-test
  namespace: default
spec:
  name: rds-db-test
  queries:
  - id: rds_db_test
    metricStat:
      metric:
        dimensions:
        - name: DBInstanceIdentifier
          value: foobar
        metricName: CPUUtilization
        namespace: AWS/RDS
      period: 600
      stat: Average
      unit: Percent
    returnData: false
  - expression: AVG(METRICS())
    id: rds_db_avg_test
    returnData: true
  resource:
    resource: deployment
```

This produces the following error:

```
kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/rds-db-test"
Error from server (BadRequest): InvalidParameter: 3 validation error(s) found.
- minimum field value of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Period.
- minimum field size of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Metric.MetricName.
- minimum field size of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Metric.Namespace.
```

This can also be replicated locally with the following program:

```
package main

import (
	"flag"
	"fmt"
	"log"

	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/aws"
	"github.com/awslabs/k8s-cloudwatch-adapter/pkg/config"
)

func main() {
	flag.Parse()
	c := aws.NewCloudWatchClient()
	queries := []config.MetricDataQuery{
		{
			ID: "rds_db_test",
			MetricStat: config.MetricStat{
				Metric: config.Metric{
					Dimensions: []config.Dimension{
						{
							Name:  "DBInstanceIdentifier",
							Value: "foobar",
						},
					},
					MetricName: "CPUUtilization",
					Namespace:  "AWS/RDS",
				},
				Period: 600,
				Stat:   "Average",
				Unit:   "Percent",
			},
			ReturnData: false,
		},
		{
			ID:         "rds_db_avg_test",
			Expression: "AVG(METRICS())",
			ReturnData: true,
		},
	}
	r, err := c.Query(queries)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(r)
}
```
Running this produces the following validation error without the fix:
```
E0807 13:22:22.033542   18945 client.go:98] err: InvalidParameter: 3 validation error(s) found.
- minimum field value of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Period.
- minimum field size of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Metric.MetricName.
- minimum field size of 1, GetMetricDataInput.MetricDataQueries[0].MetricStat.Metric.Namespace.
```
The fix allows it to run as expected without any error.

*Description of changes:*

* Data is copied when looping over queries (`q := q`) 
* The loop is refactored to remove redundant logic when handling expressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
