### PR TITLE
Remove custom.metrics api service

### DIFF
--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -108,20 +108,6 @@ spec:
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1beta1.custom.metrics.k8s.io
-spec:
-  service:
-    name: k8s-cloudwatch-adapter
-    namespace: custom-metrics
-  group: custom.metrics.k8s.io
-  version: v1beta1
-  insecureSkipTLSVerify: true
-  groupPriorityMinimum: 100
-  versionPriority: 100
----
-apiVersion: apiregistration.k8s.io/v1beta1
-kind: APIService
-metadata:
   name: v1beta1.external.metrics.k8s.io
 spec:
   service:
@@ -132,16 +118,6 @@ spec:
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: k8s-cloudwatch-adapter:custom-metrics-reader
-rules:
-- apiGroups:
-  - custom.metrics.k8s.io
-  resources: ["*"]
-  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**Issue** #15 

custom.metrics.k8s.io api service not needed and it break Helm 3 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
