### PR TITLE
Use `targetAverageValue` in example HPA configuration

### DIFF
--- a/samples/sqs/deploy/hpa.yaml
+++ b/samples/sqs/deploy/hpa.yaml
@@ -13,5 +13,4 @@ spec:
   - type: External
     external:
       metricName: sqs-helloworld-length
-      targetValue: 30
-
+      targetAverageValue: 30


### PR DESCRIPTION
The example HPA configuration is incorrect.  The queue depth should be divided by the number of running pods, instead of used as an absolute number. 

AWS's [auto scaling documentation](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-using-sqs-queue.html#scale-sqs-queue-custom-metric) explains why:

> The number of messages in your Amazon SQS queue does not solely define the number of instances needed. In fact, the number of instances in the fleet can be driven by multiple factors, including how long it takes to process a message and the acceptable amount of latency (queue delay).

> The solution is to use a _backlog per instance_ metric with the target value being the acceptable backlog per instance to maintain. ...

See also the [discussion here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/), which also uses the average value for a queue depth metric.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
