### PR TITLE
Fix AWS IAM Roles for Service Accounts permission problem

### DIFF
--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -49,6 +49,8 @@ spec:
       name: k8s-cloudwatch-adapter
     spec:
       serviceAccountName: k8s-cloudwatch-adapter
+      securityContext:
+        fsGroup: 65534
       containers:
       - name: k8s-cloudwatch-adapter
         image: chankh/k8s-cloudwatch-adapter:v0.9.0


### PR DESCRIPTION
AWS IRSA permission problem fix

*Issue #, if available:* #46 

The pod running adapter is unable to read the token file available in the service account. It gives the error
`unable to read file at /var/run/secrets/eks.amazonaws.com/serviceaccount/token: permission denied`

*Description of changes:*
Setting security context for the pod solves the issue: 
```
securityContext:
    fsGroup: 65534
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
