### PR TITLE
Fixed deployment pod annotations yaml indentation

### DIFF
--- a/charts/k8s-cloudwatch-adapter/templates/deployment.yaml
+++ b/charts/k8s-cloudwatch-adapter/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       {{- if .Values.podAnnotations }}
-        annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
+      annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "k8s-cloudwatch-adapter.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The annotations key in the deployment metadata was incorrectly indented. This fixes the indentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
