### PR TITLE
Set chart type to application

### DIFF
--- a/charts/k8s-cloudwatch-adapter-crd/Chart.yaml
+++ b/charts/k8s-cloudwatch-adapter-crd/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-cloudwatch-adapter-crd
 description: Helm chart for Kubernetes metrics adapter crd for Amazon CloudWatch
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.10.0

--- a/charts/k8s-cloudwatch-adapter-crd/Chart.yaml
+++ b/charts/k8s-cloudwatch-adapter-crd/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-cloudwatch-adapter-crd
 description: Helm chart for Kubernetes metrics adapter crd for Amazon CloudWatch
-type: library
+type: application
 version: 0.1.0
 appVersion: 0.10.0


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/k8s-cloudwatch-adapter/issues/58

*Description of changes:*
Cannot install type library type

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
