### PR TITLE
Allow adapter to view get/list configmaps

### DIFF
--- a/charts/k8s-cloudwatch-adapter/Chart.yaml
+++ b/charts/k8s-cloudwatch-adapter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-cloudwatch-adapter
 description: Helm chart for Kubernetes metrics adapter for Amazon CloudWatch
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.10.0

--- a/charts/k8s-cloudwatch-adapter/templates/rbac.yaml
+++ b/charts/k8s-cloudwatch-adapter/templates/rbac.yaml
@@ -69,6 +69,7 @@ rules:
   - namespaces
   - pods
   - services
+  - configmaps
   verbs:
   - get
   - list

--- a/deploy/adapter.yaml
+++ b/deploy/adapter.yaml
@@ -142,6 +142,7 @@ rules:
   - namespaces
   - pods
   - services
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On startup, depending on the authentication method, the kubernetes client may try to load the CA bundle from the configmaps but currently that clusterrole does not have access to do so

``` sh
2020-09-24T15:28:37.832744648Z + kubectl wait --for=condition=Ready pod/k8s-cloudwatch-adapter-85dbcdf6d8-6cdzl --timeout=180s -n kube-system
2020-09-24T15:28:37.889532587Z pod/k8s-cloudwatch-adapter-85dbcdf6d8-6cdzl condition met
2020-09-24T15:28:37.890851514Z + sleep 30
2020-09-24T15:29:07.891827306Z + kubectl logs k8s-cloudwatch-adapter-85dbcdf6d8-6cdzl -n kube-system
2020-09-24T15:29:07.962934387Z I0924 15:28:34.773418       1 controller.go:35] Setting up external metric event handlers
2020-09-24T15:29:07.962959388Z I0924 15:28:34.773554       1 controller.go:57] initializing controller
2020-09-24T15:29:07.962963637Z I0924 15:28:34.792642       1 adapter.go:101] CloudWatch metrics adapter started
2020-09-24T15:29:07.962966707Z I0924 15:28:34.874192       1 controller.go:65] starting 2 workers with 1000000000 interval
2020-09-24T15:29:07.962971913Z I0924 15:28:34.874235       1 controller.go:76] Worker starting
2020-09-24T15:29:07.962976310Z I0924 15:28:34.874240       1 controller.go:86] processing item
2020-09-24T15:29:07.962980644Z I0924 15:28:34.874251       1 controller.go:76] Worker starting
2020-09-24T15:29:07.962984873Z I0924 15:28:34.874254       1 controller.go:86] processing item
2020-09-24T15:29:07.962988511Z I0924 15:28:35.060945       1 serving.go:306] Generated self-signed cert (/tmp/apiserver.crt, /tmp/apiserver.key)
2020-09-24T15:29:07.963001635Z W0924 15:28:35.426114       1 configmap_cafile_content.go:102] unable to load initial CA bundle for: "client-ca::kube-system::extension-apiserver-authentication::client-ca-file" due to: configmap "extension-apiserver-authentication" not found
2020-09-24T15:29:07.963005230Z W0924 15:28:35.426154       1 configmap_cafile_content.go:102] unable to load initial CA bundle for: "client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file" due to: configmap "extension-apiserver-authentication" not found
2020-09-24T15:29:07.963008666Z I0924 15:28:35.430537       1 configmap_cafile_content.go:205] Starting client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
2020-09-24T15:29:07.963011815Z I0924 15:28:35.430539       1 configmap_cafile_content.go:205] Starting client-ca::kube-system::extension-apiserver-authentication::client-ca-file
2020-09-24T15:29:07.963015305Z I0924 15:28:35.430576       1 shared_informer.go:197] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
2020-09-24T15:29:07.963018135Z I0924 15:28:35.430568       1 shared_informer.go:197] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
2020-09-24T15:29:07.963020907Z I0924 15:28:35.430893       1 dynamic_serving_content.go:129] Starting serving-cert::/tmp/apiserver.crt::/tmp/apiserver.key
2020-09-24T15:29:07.963024383Z I0924 15:28:35.430952       1 tlsconfig.go:179] loaded serving cert ["serving-cert::/tmp/apiserver.crt::/tmp/apiserver.key"]: "localhost@1600961315" [serving] validServingFor=[127.0.0.1,localhost,localhost] issuer="localhost-ca@1600961314" (2020-09-24 14:28:34 +0000 UTC to 2021-09-24 14:28:34 +0000 UTC (now=2020-09-24 15:28:35.430929683 +0000 UTC))
2020-09-24T15:29:07.963028065Z I0924 15:28:35.431127       1 named_certificates.go:52] loaded SNI cert [0/"self-signed loopback"]: "apiserver-loopback-client@1600961315" [serving] validServingFor=[apiserver-loopback-client] issuer="apiserver-loopback-client-ca@1600961315" (2020-09-24 14:28:35 +0000 UTC to 2021-09-24 14:28:35 +0000 UTC (now=2020-09-24 15:28:35.43111932 +0000 UTC))
2020-09-24T15:29:07.963031504Z I0924 15:28:35.431152       1 secure_serving.go:178] Serving securely on [::]:6443
2020-09-24T15:29:07.963033970Z I0924 15:28:35.431170       1 tlsconfig.go:219] Starting DynamicServingCertificateController
2020-09-24T15:29:07.963036495Z E0924 15:28:35.431862       1 reflector.go:153] k8s.io/apiserver/pkg/server/dynamiccertificates/configmap_cafile_content.go:209: Failed to list *v1.ConfigMap: configmaps "extension-apiserver-authentication" is forbidden: User "system:serviceaccount:kube-system:k8s-cloudwatch-adapter" cannot list resource "configmaps" in API group "" in the namespace "kube-system"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
