### PR TITLE
Allow environment variables to be passed into cloudwatch-adapter pod

### DIFF
--- a/charts/k8s-cloudwatch-adapter/Chart.yaml
+++ b/charts/k8s-cloudwatch-adapter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8s-cloudwatch-adapter
 description: Helm chart for Kubernetes metrics adapter for Amazon CloudWatch
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.10.0

--- a/charts/k8s-cloudwatch-adapter/templates/deployment.yaml
+++ b/charts/k8s-cloudwatch-adapter/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
         {{- range $key, $val := .Values.args }}
         - --{{ $key }}={{ $val }}
         {{- end }}
+        env:
+        {{- range $map := .Values.env }}
+          - name: {{ $map.name }}
+            value: {{ $map.value }}
+        {{- end }}
         ports:
         - containerPort: 6443
           name: https

--- a/charts/k8s-cloudwatch-adapter/values.yaml
+++ b/charts/k8s-cloudwatch-adapter/values.yaml
@@ -20,6 +20,11 @@ args:
   logtostderr: true
   v: 2
 
+## Pod environment variables
+env:
+  # e.g. - name: AWS_REGION
+  # e.g.   value: eu-west-1
+
 replicaCount: 1
 
 ## Labels to be added to the adapter Deployment


### PR DESCRIPTION
*Description of changes:*
We have recently started to use k8s-cloudwatch-adapter in a production environment and have the requirement to inject environment variables into the "k8s-cloudwatch-adapter" pod. This PR adds an "env:" section to the deployment specification within the cloudwatch-adapter chart that will accept a list of key/value pairs, the values file has also been updated to include an example of how this could be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
