### PR TITLE
Remove '>' from README and add newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
+
 $ helm install k8s-cloudwatch-adapter ./charts/k8s-cloudwatch-adapter \
->   --namespace custom-metrics \
->   --create-namespace
+    --namespace custom-metrics \
+    --create-namespace
 NAME: k8s-cloudwatch-adapter
 LAST DEPLOYED: Fri Aug 14 13:20:17 2020
 NAMESPACE: custom-metrics


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Kept copying the helm install command with the `>` included resulting in errors. Additionally i kept missing the two commands as they are so close together i didn't visually see that it was two commands.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
