### PR TITLE
Let it work when no metadata is available

### DIFF
--- a/pkg/aws/util.go
+++ b/pkg/aws/util.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -11,8 +12,14 @@ import (
 	"k8s.io/klog"
 )
 
-// GetLocalRegion gets the region ID from the instance metadata.
+// GetLocalRegion gets the region ID from the standard environment variables or instance metadata.
 func GetLocalRegion() string {
+	if mp := os.Getenv("AWS_DEFAULT_REGION"); mp != "" {
+		return mp
+	}
+	if mp := os.Getenv("AWS_REGION"); mp != "" {
+		return mp
+	}
 	resp, err := http.Get("http://169.254.169.254/latest/meta-data/placement/availability-zone/")
 	if err != nil {
 		klog.Errorf("unable to get current region information, %v", err)


### PR DESCRIPTION
As per [EKS security best practices](https://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html), we'd like to restrict access to EC2 metadata. Serviceaccount roles allow to assume IAM roles by pods.
Unless I'm missing something, there's no reason for the program to fail when there's no metadata

This adds an option to override the region using standard environment variables - `AWS_DEFAULT_REGION` or `AWS_REGION`
  
  
  
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
