### PR TITLE
add capability test to apiVersion apiextensions.k8s.io/v1 on CRD

### DIFF
--- a/charts/k8s-cloudwatch-adapter-crd/templates/crd.yaml
+++ b/charts/k8s-cloudwatch-adapter-crd/templates/crd.yaml
@@ -1,4 +1,9 @@
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
+apiVersion: apiextensions.k8s.io/v1
+{{- else }}
 apiVersion: apiextensions.k8s.io/v1beta1
+{{- end }}
+
 kind: CustomResourceDefinition
 metadata:
   name: externalmetrics.metrics.aws


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

add capability test to apiVersion apiextensions.k8s.io/v1 on CRD since apiextensions.k8s.io/v1beta1 was removed in eks v1.19.0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
